### PR TITLE
Fix: update ethers-rs and fastrlp

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,11 +24,7 @@ eyre = "0.6.5"
 ethereum-types = { version = "0.13", features = ["codec"] }
 hex-literal = "0.3"
 mdbx = { package = "libmdbx", version = "0.1" }
-fastrlp = { version = "0.1", features = [
-    "derive",
-    "ethereum-types",
-    "std",
-] }
+fastrlp = { version = "0.1.2", features = [ "derive", "ethereum-types", "std" ] }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = "1"
 tiny-keccak = "2.0"
@@ -46,7 +42,7 @@ once_cell = "1"
 hex = { version = "0.4.3", default-features = false, features = ["std"] }
 
 [build-dependencies]
-ethers = { git = "https://github.com/gakonst/ethers-rs" }
+ethers = { git = "https://github.com/gakonst/ethers-rs", features = ["ethers-solc"] }
 eyre = "0.6.6"
 semver = "1.0.4"
 serde_json = "1.0.64"
@@ -59,4 +55,3 @@ ethers-types = ["ethers"]
 
 [patch.crates-io]
 libmdbx = { git = "https://github.com/gio256/libmdbx-rs", branch = "develop" }
-fastrlp = { git = "https://github.com/gio256/fastrlp", branch = "develop" }

--- a/build.rs
+++ b/build.rs
@@ -26,7 +26,7 @@ fn main() -> Result<()> {
 
     let mut bindings = String::new();
     for name in contracts_to_bind {
-        let contract = output.find(name).ok_or_else(|| {
+        let contract = output.find_first(name).ok_or_else(|| {
             eyre!(
                 "Could Not bind contract {}. Compiler output not found.",
                 name

--- a/src/erigon/macros.rs
+++ b/src/erigon/macros.rs
@@ -303,7 +303,6 @@ macro_rules! decl_u256_wrapper {
             ::serde::Deserialize,
             ::fastrlp::RlpEncodable,
             ::fastrlp::RlpDecodableWrapper,
-            ::fastrlp::RlpMaxEncodedLen,
         )]
         #[serde(transparent)]
         #[repr(transparent)]


### PR DESCRIPTION
Fixes #3.

Thanks to [fastrlp#3](https://github.com/vorot93/fastrlp/pull/3), we don't need the fastrlp patch anymore.